### PR TITLE
Modified convert_emiss to use an automatic year-by-year emissions scaling

### DIFF
--- a/chem/Makefile_org
+++ b/chem/Makefile_org
@@ -145,9 +145,9 @@ DRIVERS : $(OBJS)
 
 include ../configure.wrf
 
-convert_emiss : convert_emiss.o
+convert_emiss : module_emiss_scale.o convert_emiss.o 
 	$(RANLIB) ../main/$(LIBWRFLIB)
-	$(FC) -o convert_emiss.exe $(LDFLAGS) convert_emiss.o ../main/$(LIBWRFLIB) $(LIB)
+	$(FC) -o convert_emiss.exe $(LDFLAGS) module_emiss_scale.o convert_emiss.o ../main/$(LIBWRFLIB) $(LIB)
 
 clean:
 	@ echo 'use the clean script'

--- a/chem/convert_emiss.F
+++ b/chem/convert_emiss.F
@@ -25,6 +25,7 @@ PROGRAM convert_emissions
    USE module_configure, ONLY : grid_config_rec_type, model_config_rec, &
         initial_config, get_config_as_buffer, set_config_as_buffer
    USE module_io_domain
+   USE module_emiss_scale
 
 #ifdef DM_PARALLEL
    USE module_dm
@@ -127,6 +128,7 @@ PROGRAM convert_emissions
    INTEGER :: interval_seconds , real_data_init_type
    INTEGER :: int_sec
    INTEGER :: time_loop_max , time_loop
+   INTEGER :: nei_base_yr = 2011
 
    REAL :: cen_lat, cen_lon, moad_cen_lat, truelat1, truelat2, gmt, stand_lon, dum1
    INTEGER :: map_proj, julyr, julday, iswater, isice, isurban, isoilwater
@@ -1743,7 +1745,7 @@ PROGRAM convert_emissions
      write(message, FMT='(A,5I10)') ' dims:',size(dumc0,1),size(dumc0,2),size(dumc0,3)
      call wrf_message( TRIM( message ) )
     write(*,*) dumc0(ids:ide-1,1,7)
-         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_so2)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*0.78 !Azimeh: scale from 2011 to 2013
+         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_so2)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*so2_scale(start_year, nei_base_yr) !Azimeh: scale from 2011 to 2013
     write(*,*) grid%emis_ant(ips:ipe-1,1,7,p_e_so2)
 #ifdef DM_PARALLEL
      IF (wrf_dm_on_monitor()) THEN
@@ -1754,7 +1756,7 @@ PROGRAM convert_emissions
 
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
 #endif
-         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_no)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*0.889 !Azimeh: scale from 2011 to 2013+reduce no emissions from NEI 2011 50% following the other run and comparison with obs
+         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_no)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*nox_scale(start_year, nei_base_yr) !Azimeh: scale from 2011 to 2013+reduce no emissions from NEI 2011 50% following the other run and comparison with obs
 
 !AQMII
 !Azimeh: for NEI 2011 & 2005 e_no2 bayad hazf beshe: vali bekhatere if nemikhonadesh
@@ -1778,7 +1780,7 @@ PROGRAM convert_emissions
 #else
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
 #endif
-         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_ald)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  ) *0.95 !Azimeh: scale from 2011 to 2013
+         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_ald)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  ) *voc_scale(start_year, nei_base_yr) !Azimeh: scale from 2011 to 2013
 #ifdef DM_PARALLEL
      IF (wrf_dm_on_monitor()) THEN
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
@@ -1787,7 +1789,7 @@ PROGRAM convert_emissions
 #else
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
 #endif
-         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_hcho)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*0.95 !Azimeh: scale from 2011 to 2013
+         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_hcho)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*voc_scale(start_year, nei_base_yr) !Azimeh: scale from 2011 to 2013
 #ifdef DM_PARALLEL
      IF (wrf_dm_on_monitor()) THEN
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
@@ -1796,7 +1798,7 @@ PROGRAM convert_emissions
 #else
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
 #endif
-         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_ora2)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*0.95 !Azimeh: scale from 2011 to 2013
+         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_ora2)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*voc_scale(start_year, nei_base_yr) !Azimeh: scale from 2011 to 2013
 #ifdef DM_PARALLEL
      IF (wrf_dm_on_monitor()) THEN
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
@@ -1805,7 +1807,7 @@ PROGRAM convert_emissions
 #else
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
 #endif
-         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_nh3)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*0.99 !Azimeh: scale from 2011 to 2013
+         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_nh3)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*nh3_scale(start_year, nei_base_yr) !Azimeh: scale from 2011 to 2013
 #ifdef DM_PARALLEL
      IF (wrf_dm_on_monitor()) THEN
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
@@ -1814,7 +1816,7 @@ PROGRAM convert_emissions
 #else
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
 #endif
-         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_hc3)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*0.95 !Azimeh: scale from 2011 to 2013
+         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_hc3)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*voc_scale(start_year, nei_base_yr) !Azimeh: scale from 2011 to 2013
 #ifdef DM_PARALLEL
      IF (wrf_dm_on_monitor()) THEN
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
@@ -1823,7 +1825,7 @@ PROGRAM convert_emissions
 #else
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
 #endif
-         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_hc5)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*0.95 !Azimeh: scale from 2011 to 2013
+         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_hc5)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*voc_scale(start_year, nei_base_yr) !Azimeh: scale from 2011 to 2013
 #ifdef DM_PARALLEL
      IF (wrf_dm_on_monitor()) THEN
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
@@ -1832,7 +1834,7 @@ PROGRAM convert_emissions
 #else
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
 #endif
-         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_hc8)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*0.95 !Azimeh: scale from 2011 to 2013
+         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_hc8)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*voc_scale(start_year, nei_base_yr) !Azimeh: scale from 2011 to 2013
 #ifdef DM_PARALLEL
      IF (wrf_dm_on_monitor()) THEN
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
@@ -1841,7 +1843,7 @@ PROGRAM convert_emissions
 #else
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
 #endif
-         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_eth)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*0.95 !Azimeh: scale from 2011 to 2013
+         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_eth)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*voc_scale(start_year, nei_base_yr) !Azimeh: scale from 2011 to 2013
 #ifdef DM_PARALLEL
      IF (wrf_dm_on_monitor()) THEN
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
@@ -1850,7 +1852,7 @@ PROGRAM convert_emissions
 #else
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
 #endif
-         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_co)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*0.934 !Azimeh: scale from 2011 to 2013
+         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_co)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*co_scale(start_year, nei_base_yr) !Azimeh: scale from 2011 to 2013
 #ifdef DM_PARALLEL
      IF (wrf_dm_on_monitor()) THEN
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
@@ -1859,7 +1861,7 @@ PROGRAM convert_emissions
 #else
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
 #endif
-         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_ol2)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*0.95 !Azimeh: scale from 2011 to 2013
+         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_ol2)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*voc_scale(start_year, nei_base_yr) !Azimeh: scale from 2011 to 2013
 #ifdef DM_PARALLEL
      IF (wrf_dm_on_monitor()) THEN
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
@@ -1868,7 +1870,7 @@ PROGRAM convert_emissions
 #else
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
 #endif
-         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_olt)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*0.95 !Azimeh: scale from 2011 to 2013
+         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_olt)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*voc_scale(start_year, nei_base_yr) !Azimeh: scale from 2011 to 2013
 #ifdef DM_PARALLEL
      IF (wrf_dm_on_monitor()) THEN
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
@@ -1877,7 +1879,7 @@ PROGRAM convert_emissions
 #else
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
 #endif
-         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_oli)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*0.95 !Azimeh: scale from 2011 to 2013
+         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_oli)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*voc_scale(start_year, nei_base_yr) !Azimeh: scale from 2011 to 2013
 #ifdef DM_PARALLEL
      IF (wrf_dm_on_monitor()) THEN
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
@@ -1886,7 +1888,7 @@ PROGRAM convert_emissions
 #else
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
 #endif
-         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_tol)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*0.95 !Azimeh: scale from 2011 to 2013
+         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_tol)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*voc_scale(start_year, nei_base_yr) !Azimeh: scale from 2011 to 2013
 #ifdef DM_PARALLEL
      IF (wrf_dm_on_monitor()) THEN
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
@@ -1895,7 +1897,7 @@ PROGRAM convert_emissions
 #else
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
 #endif
-         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_xyl)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*0.95 !Azimeh: scale from 2011 to 2013
+         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_xyl)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*voc_scale(start_year, nei_base_yr) !Azimeh: scale from 2011 to 2013
 #ifdef DM_PARALLEL
      IF (wrf_dm_on_monitor()) THEN
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
@@ -1904,7 +1906,7 @@ PROGRAM convert_emissions
 #else
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
 #endif
-         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_ket)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*0.95 !Azimeh: scale from 2011 to 2013
+         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_ket)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*voc_scale(start_year, nei_base_yr) !Azimeh: scale from 2011 to 2013
 #ifdef DM_PARALLEL
      IF (wrf_dm_on_monitor()) THEN
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
@@ -1913,7 +1915,7 @@ PROGRAM convert_emissions
 #else
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
 #endif
-         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_csl)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*0.95 !Azimeh: scale from 2011 to 2013
+         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_csl)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*voc_scale(start_year, nei_base_yr) !Azimeh: scale from 2011 to 2013
 #ifdef DM_PARALLEL
      IF (wrf_dm_on_monitor()) THEN
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
@@ -1922,7 +1924,7 @@ PROGRAM convert_emissions
 #else
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
 #endif
-         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_iso)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*0.95 !Azimeh: scale from 2011 to 2013
+         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_iso)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*voc_scale(start_year, nei_base_yr) !Azimeh: scale from 2011 to 2013
 #ifdef DM_PARALLEL
 !!!Azimeh :Add this treetment for e_ch4 to use NEI 2011 instead of NEI 2005
 ! it must be added to Registry/registry.chem as well at emiss_opt==3       
@@ -1933,7 +1935,7 @@ PROGRAM convert_emissions
 #else
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
 #endif
-         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_ch4)=dumc0(ips:ipe,kps:grid%kemit,jps:jpe  )*0.95 !Azimeh: scale from 2011 to 2013
+         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_ch4)=dumc0(ips:ipe,kps:grid%kemit,jps:jpe  )*voc_scale(start_year, nei_base_yr) !Azimeh: scale from 2011 to 2013
 #ifdef DM_PARALLEL
 !!Azimeh
      IF (wrf_dm_on_monitor()) THEN
@@ -1943,7 +1945,7 @@ PROGRAM convert_emissions
 #else
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
 #endif
-         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_pm25i)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*0.99 !Azimeh: scale from 2011 to 2013
+         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_pm25i)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*pm25_scale(start_year, nei_base_yr) !Azimeh: scale from 2011 to 2013
 #ifdef DM_PARALLEL
      IF (wrf_dm_on_monitor()) THEN
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
@@ -1952,7 +1954,7 @@ PROGRAM convert_emissions
 #else
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
 #endif
-         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_pm25j)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*0.99 !Azimeh: scale from 2011 to 2013
+         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_pm25j)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*pm25_scale(start_year, nei_base_yr) !Azimeh: scale from 2011 to 2013
 #ifdef DM_PARALLEL
      IF (wrf_dm_on_monitor()) THEN
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
@@ -1961,7 +1963,7 @@ PROGRAM convert_emissions
 #else
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
 #endif
-         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_so4i)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*0.99 !Azimeh: scale from 2011 to 2013
+         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_so4i)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*pm25_scale(start_year, nei_base_yr) !Azimeh: scale from 2011 to 2013 !Josh: this follows pm2.5?
 #ifdef DM_PARALLEL
      IF (wrf_dm_on_monitor()) THEN
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
@@ -1970,7 +1972,7 @@ PROGRAM convert_emissions
 #else
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
 #endif
-         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_so4j)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*0.99 !Azimeh: scale from 2011 to 2013
+         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_so4j)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*pm25_scale(start_year, nei_base_yr) !Azimeh: scale from 2011 to 2013 !Josh: this follows pm2.5?
 #ifdef DM_PARALLEL
      IF (wrf_dm_on_monitor()) THEN
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
@@ -1979,7 +1981,7 @@ PROGRAM convert_emissions
 #else
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
 #endif
-         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_no3i)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*0.99 !Azimeh: scale from 2011 to 2013
+         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_no3i)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*pm25_scale(start_year, nei_base_yr) !Azimeh: scale from 2011 to 2013 !Josh: this follows pm2.5?
 #ifdef DM_PARALLEL
      IF (wrf_dm_on_monitor()) THEN
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
@@ -1988,7 +1990,7 @@ PROGRAM convert_emissions
 #else
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
 #endif
-         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_no3j)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*0.99 !Azimeh: scale from 2011 to 2013
+         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_no3j)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*pm25_scale(start_year, nei_base_yr) !Azimeh: scale from 2011 to 2013 !Josh: this follows pm2.5?
 
 !     IF (inew_nei .eq. 1) THEN
 !!! naai and naaj for aqmeii
@@ -2020,7 +2022,7 @@ PROGRAM convert_emissions
 #else
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
 #endif
-         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_orgi)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*0.99 !Azimeh: scale from 2011 to 2013
+         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_orgi)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*pm25_scale(start_year, nei_base_yr) !Azimeh: scale from 2011 to 2013 !Josh: follows pm2.5?
 #ifdef DM_PARALLEL
      IF (wrf_dm_on_monitor()) THEN
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
@@ -2029,7 +2031,7 @@ PROGRAM convert_emissions
 #else
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
 #endif
-         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_orgj)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*0.99 !Azimeh: scale from 2011 to 2013
+         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_orgj)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*pm25_scale(start_year, nei_base_yr) !Azimeh: scale from 2011 to 2013 !Josh: follows pm2.5?
 #ifdef DM_PARALLEL
      IF (wrf_dm_on_monitor()) THEN
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
@@ -2038,7 +2040,7 @@ PROGRAM convert_emissions
 #else
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
 #endif
-         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_eci)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*0.99 !Azimeh: scale from 2011 to 2013
+         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_eci)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*pm25_scale(start_year, nei_base_yr) !Josh: follows pm2.5? !Azimeh: scale from 2011 to 2013
 #ifdef DM_PARALLEL
      IF (wrf_dm_on_monitor()) THEN
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
@@ -2047,7 +2049,7 @@ PROGRAM convert_emissions
 #else
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
 #endif
-         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_ecj)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*0.99 !Azimeh: scale from 2011 to 2013
+         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_ecj)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*pm25_scale(start_year, nei_base_yr) !Josh: follows pm2.5? !Azimeh: scale from 2011 to 2013
 #ifdef DM_PARALLEL
      IF (wrf_dm_on_monitor()) THEN
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
@@ -2058,7 +2060,7 @@ PROGRAM convert_emissions
 #endif
 !Azimeh
 !        write(*,*) dumc0(ids:ide-1,1,19)
-         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_pm_10)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  ) *0.996 !Azimeh: scale from 2011 to 2013
+         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_pm_10)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  ) *pm10_scale(start_year, nei_base_yr) !Azimeh: scale from 2011 to 2013
 !Azimeh test
 !        write(*,*) grid%emis_ant(ips:ipe-1,1,19,p_e_pm_10)
    write(message,FMT='(A)') ' PAST READ EMISSIONS 1'
@@ -2257,7 +2259,7 @@ PROGRAM convert_emissions
 #else
         read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
 #endif
-         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_so2)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*0.78 !Azimeh: scale from 2011 to 2013
+         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_so2)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*so2_scale(start_year, nei_base_yr) !Azimeh: scale from 2011 to 2013
 !
 #ifdef DM_PARALLEL
      IF (wrf_dm_on_monitor()) THEN
@@ -2268,7 +2270,7 @@ PROGRAM convert_emissions
 
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
 #endif
-         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_no)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*0.889  !Azimeh: scale from 2011 to 2013+reduce no emissions from NEI 2011 50% following the other run and comparison with obs
+         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_no)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*nox_scale(start_year, nei_base_yr)  !Azimeh: scale from 2011 to 2013+reduce no emissions from NEI 2011 50% following the other run and comparison with obs
 
 !     IF (inew_nei .eq. 1) THEN
 !#ifdef DM_PARALLEL
@@ -2291,7 +2293,7 @@ PROGRAM convert_emissions
 #else
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
 #endif
-         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_ald)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*0.95 !Azimeh: scale from 2011 to 2013
+         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_ald)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*voc_scale(start_year, nei_base_yr) !Azimeh: scale from 2011 to 2013
 #ifdef DM_PARALLEL
      IF (wrf_dm_on_monitor()) THEN
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
@@ -2300,7 +2302,7 @@ PROGRAM convert_emissions
 #else
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
 #endif
-         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_hcho)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*0.95 !Azimeh: scale from 2011 to 2013
+         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_hcho)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*voc_scale(start_year, nei_base_yr) !Azimeh: scale from 2011 to 2013
 #ifdef DM_PARALLEL
      IF (wrf_dm_on_monitor()) THEN
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
@@ -2309,7 +2311,7 @@ PROGRAM convert_emissions
 #else
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
 #endif
-         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_ora2)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*0.95 !Azimeh: scale from 2011 to 2013
+         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_ora2)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*voc_scale(start_year, nei_base_yr) !Azimeh: scale from 2011 to 2013
 #ifdef DM_PARALLEL
      IF (wrf_dm_on_monitor()) THEN
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
@@ -2318,7 +2320,7 @@ PROGRAM convert_emissions
 #else
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
 #endif
-         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_nh3)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*0.99 !Azimeh: scale from 2011 to 2013
+         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_nh3)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*nh3_scale(start_year, nei_base_yr) !Azimeh: scale from 2011 to 2013
 #ifdef DM_PARALLEL
      IF (wrf_dm_on_monitor()) THEN
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
@@ -2327,7 +2329,7 @@ PROGRAM convert_emissions
 #else
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
 #endif
-         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_hc3)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*0.95 !Azimeh: scale from 2011 to 2013
+         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_hc3)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*voc_scale(start_year, nei_base_yr) !Azimeh: scale from 2011 to 2013
 #ifdef DM_PARALLEL
      IF (wrf_dm_on_monitor()) THEN
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
@@ -2336,7 +2338,7 @@ PROGRAM convert_emissions
 #else
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
 #endif
-         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_hc5)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*0.95 !Azimeh: scale from 2011 to 2013
+         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_hc5)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*voc_scale(start_year, nei_base_yr) !Azimeh: scale from 2011 to 2013
 #ifdef DM_PARALLEL
      IF (wrf_dm_on_monitor()) THEN
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
@@ -2345,7 +2347,7 @@ PROGRAM convert_emissions
 #else
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
 #endif
-         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_hc8)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*0.95 !Azimeh: scale from 2011 to 2013
+         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_hc8)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*voc_scale(start_year, nei_base_yr) !Azimeh: scale from 2011 to 2013
 #ifdef DM_PARALLEL
      IF (wrf_dm_on_monitor()) THEN
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
@@ -2354,7 +2356,7 @@ PROGRAM convert_emissions
 #else
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
 #endif
-         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_eth)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*0.95 !Azimeh: scale from 2011 to 2013
+         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_eth)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*voc_scale(start_year, nei_base_yr) !Azimeh: scale from 2011 to 2013
 #ifdef DM_PARALLEL
      IF (wrf_dm_on_monitor()) THEN
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
@@ -2363,7 +2365,7 @@ PROGRAM convert_emissions
 #else
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
 #endif
-         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_co)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*0.934 !Azimeh: scale from 2011 to 2013
+         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_co)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*co_scale(start_year, nei_base_yr) !Azimeh: scale from 2011 to 2013
 #ifdef DM_PARALLEL
      IF (wrf_dm_on_monitor()) THEN
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
@@ -2372,7 +2374,7 @@ PROGRAM convert_emissions
 #else
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
 #endif
-         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_ol2)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*0.95 !Azimeh: scale from 2011 to 2013
+         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_ol2)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*voc_scale(start_year, nei_base_yr) !Azimeh: scale from 2011 to 2013
 #ifdef DM_PARALLEL
      IF (wrf_dm_on_monitor()) THEN
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
@@ -2381,7 +2383,7 @@ PROGRAM convert_emissions
 #else
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
 #endif
-         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_olt)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*0.95 !Azimeh: scale from 2011 to 2013
+         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_olt)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*voc_scale(start_year, nei_base_yr) !Azimeh: scale from 2011 to 2013
 #ifdef DM_PARALLEL
      IF (wrf_dm_on_monitor()) THEN
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
@@ -2390,7 +2392,7 @@ PROGRAM convert_emissions
 #else
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
 #endif
-         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_oli)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*0.95 !Azimeh: scale from 2011 to 2013
+         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_oli)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*voc_scale(start_year, nei_base_yr) !Azimeh: scale from 2011 to 2013
 #ifdef DM_PARALLEL
      IF (wrf_dm_on_monitor()) THEN
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
@@ -2399,7 +2401,7 @@ PROGRAM convert_emissions
 #else
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
 #endif
-         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_tol)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*0.95 !Azimeh: scale from 2011 to 2013
+         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_tol)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*voc_scale(start_year, nei_base_yr) !Azimeh: scale from 2011 to 2013
 #ifdef DM_PARALLEL
      IF (wrf_dm_on_monitor()) THEN
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
@@ -2408,7 +2410,7 @@ PROGRAM convert_emissions
 #else
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
 #endif
-         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_xyl)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*0.95 !Azimeh: scale from 2011 to 2013
+         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_xyl)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*voc_scale(start_year, nei_base_yr) !Azimeh: scale from 2011 to 2013
 #ifdef DM_PARALLEL
      IF (wrf_dm_on_monitor()) THEN
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
@@ -2417,7 +2419,7 @@ PROGRAM convert_emissions
 #else
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
 #endif
-         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_ket)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*0.95 !Azimeh: scale from 2011 to 2013
+         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_ket)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*voc_scale(start_year, nei_base_yr) !Azimeh: scale from 2011 to 2013
 #ifdef DM_PARALLEL
      IF (wrf_dm_on_monitor()) THEN
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
@@ -2426,7 +2428,7 @@ PROGRAM convert_emissions
 #else
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
 #endif
-         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_csl)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*0.95 !Azimeh: scale from 2011 to 2013
+         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_csl)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*voc_scale(start_year, nei_base_yr) !Azimeh: scale from 2011 to 2013
 #ifdef DM_PARALLEL
      IF (wrf_dm_on_monitor()) THEN
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
@@ -2435,7 +2437,7 @@ PROGRAM convert_emissions
 #else
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
 #endif
-         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_iso)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*0.95 !Azimeh: scale from 2011 to 2013
+         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_iso)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*voc_scale(start_year, nei_base_yr) !Azimeh: scale from 2011 to 2013
 #ifdef DM_PARALLEL
 !!!Azimeh: Add this treetment for e_ch4 to use NEI 2011 instead of NEI 2005
      IF (wrf_dm_on_monitor()) THEN
@@ -2445,7 +2447,7 @@ PROGRAM convert_emissions
 #else
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
 #endif
-         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe,p_e_ch4)=dumc0(ips:ipe,kps:grid%kemit,jps:jpe  )*0.95 !Azimeh: scale from 2011 to 2013
+         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe,p_e_ch4)=dumc0(ips:ipe,kps:grid%kemit,jps:jpe  )*voc_scale(start_year, nei_base_yr) !Azimeh: scale from 2011 to 2013
 #ifdef DM_PARALLEL
 !!Azimeh
      IF (wrf_dm_on_monitor()) THEN
@@ -2455,7 +2457,7 @@ PROGRAM convert_emissions
 #else
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
 #endif
-         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_pm25i)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*0.99 !Azimeh: scale from 2011 to 2013
+         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_pm25i)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*pm25_scale(start_year, nei_base_yr) !Azimeh: scale from 2011 to 2013
 #ifdef DM_PARALLEL
      IF (wrf_dm_on_monitor()) THEN
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
@@ -2464,7 +2466,7 @@ PROGRAM convert_emissions
 #else
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
 #endif
-         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_pm25j)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*0.99 !Azimeh: scale from 2011 to 2013
+         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_pm25j)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*pm25_scale(start_year, nei_base_yr) !Azimeh: scale from 2011 to 2013
 #ifdef DM_PARALLEL
      IF (wrf_dm_on_monitor()) THEN
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
@@ -2473,7 +2475,7 @@ PROGRAM convert_emissions
 #else
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
 #endif
-         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_so4i)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*0.99 !Azimeh: scale from 2011 to 2013
+         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_so4i)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*pm25_scale(start_year, nei_base_yr) !Josh: follows pm2.5? !Azimeh: scale from 2011 to 2013
 #ifdef DM_PARALLEL
      IF (wrf_dm_on_monitor()) THEN
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
@@ -2482,7 +2484,7 @@ PROGRAM convert_emissions
 #else
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
 #endif
-         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_so4j)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*0.99 !Azimeh: scale from 2011 to 2013
+         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_so4j)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*pm25_scale(start_year, nei_base_yr) !Josh: follows pm2.5? !Azimeh: scale from 2011 to 2013
 #ifdef DM_PARALLEL
      IF (wrf_dm_on_monitor()) THEN
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
@@ -2491,7 +2493,7 @@ PROGRAM convert_emissions
 #else
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
 #endif
-         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_no3i)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*0.99 !Azimeh: scale from 2011 to 2013
+         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_no3i)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*pm25_scale(start_year, nei_base_yr) !Josh: follows pm2.5? !Azimeh: scale from 2011 to 2013
 #ifdef DM_PARALLEL
      IF (wrf_dm_on_monitor()) THEN
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
@@ -2500,7 +2502,7 @@ PROGRAM convert_emissions
 #else
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
 #endif
-         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_no3j)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*0.99 !Azimeh: scale from 2011 to 2013
+         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_no3j)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*pm25_scale(start_year, nei_base_yr) !Josh: follows pm2.5? !Azimeh: scale from 2011 to 2013
 !
 !  AQMEII
      IF (inew_nei .eq. 1) THEN
@@ -2512,7 +2514,7 @@ PROGRAM convert_emissions
 #else
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
 #endif
-         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_naai)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*0.99 !Azimeh: scale from 2011 to 2013
+         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_naai)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*pm25_scale(start_year, nei_base_yr) !Josh: follows pm2.5? !Azimeh: scale from 2011 to 2013
 !
 #ifdef DM_PARALLEL
      IF (wrf_dm_on_monitor()) THEN
@@ -2522,7 +2524,7 @@ PROGRAM convert_emissions
 #else
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
 #endif
-         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_naaj)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*0.99 !Azimeh: scale from 2011 to 2013
+         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_naaj)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*pm25_scale(start_year, nei_base_yr) !Josh: follows pm2.5? !Azimeh: scale from 2011 to 2013
      ENDIF
 !
 #ifdef DM_PARALLEL
@@ -2533,7 +2535,7 @@ PROGRAM convert_emissions
 #else
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
 #endif
-         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_orgi)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*0.99 !Azimeh: scale from 2011 to 2013
+         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_orgi)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*pm25_scale(start_year, nei_base_yr) !Josh: follows pm2.5? !Azimeh: scale from 2011 to 2013
 #ifdef DM_PARALLEL
      IF (wrf_dm_on_monitor()) THEN
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
@@ -2542,7 +2544,7 @@ PROGRAM convert_emissions
 #else
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
 #endif
-         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_orgj)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*0.99 !Azimeh: scale from 2011 to 2013
+         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_orgj)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*pm25_scale(start_year, nei_base_yr) !Josh: follows pm2.5? !Azimeh: scale from 2011 to 2013
 #ifdef DM_PARALLEL
      IF (wrf_dm_on_monitor()) THEN
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
@@ -2551,7 +2553,7 @@ PROGRAM convert_emissions
 #else
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
 #endif
-         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_eci)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*0.99 !Azimeh: scale from 2011 to 2013
+         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_eci)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*pm25_scale(start_year, nei_base_yr) !Josh: follows pm2.5? !Azimeh: scale from 2011 to 2013
 !
 #ifdef DM_PARALLEL
      IF (wrf_dm_on_monitor()) THEN
@@ -2561,7 +2563,7 @@ PROGRAM convert_emissions
 #else
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
 #endif
-         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_ecj)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*0.99 !Azimeh: scale from 2011 to 2013
+         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_ecj)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*pm25_scale(start_year, nei_base_yr) !Josh: follows pm2.5? !Azimeh: scale from 2011 to 2013
 !
 #ifdef DM_PARALLEL
      IF (wrf_dm_on_monitor()) THEN
@@ -2571,7 +2573,7 @@ PROGRAM convert_emissions
 #else
          read(91)dumc0(ids:ide-1,kds:grid%kemit,jds:jde-1)
 #endif
-         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_pm_10)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*0.998 !Azimeh: scale from 2011 to 2013
+         grid%emis_ant(ips:ipe  ,kps:grid%kemit,jps:jpe  ,p_e_pm_10)=dumc0(ips:ipe  ,kps:grid%kemit,jps:jpe  )*pm10_scale(start_year, nei_base_yr) !Azimeh: scale from 2011 to 2013
 
      write(message,FMT='(A)') ' Past reading emissions '
      CALL  wrf_debug ( 100, message ) 

--- a/chem/module_emiss_scale.F
+++ b/chem/module_emiss_scale.F
@@ -1,0 +1,226 @@
+MODULE MODULE_EMISS_SCALE
+!
+! Module which give the factors to scale trace gas emissions by
+! based on the year of the simulation and EPA total emission
+! data available at https://www.epa.gov/air-emissions-inventories/air-pollutant-emissions-trends-data
+!
+! The scaling is extremely simple, calculating a ratio of total annual
+! emissions between the current year and the base year (2011 or 2005
+! typically). The base year will default to the value set below unless
+! a second argument is passed to the functions contained here.
+!
+! Although this has the extension .F, it is written to the Fortran 90
+! standard. WRF's clean script deletes .f90 files, but during the build
+! process, converts .F to .f90 files.
+!
+! TODO: add error if year out of range.
+IMPLICIT NONE
+
+PRIVATE YEAR_INDEX, a, def_base_yr, years, e_co, e_nox, e_pm10, e_pm25
+
+INTEGER :: a
+INTEGER, PARAMETER :: def_base_yr = 2011
+INTEGER, PARAMETER, DIMENSION(25) :: years = (/ (a, a=1990,2014) /)
+REAL*8, PARAMETER, DIMENSION(25) :: e_co = (/ 154188.0, 147128.0, 140895.0, &
+ 135902.0, 133558.0, 126778.0, 128858.0, 117910.0, 115380.0, 114541.0,      &
+ 114467.0, 106262.0, 102033.0, 99593.0, 97147.0, 88546.0, 85837.0, 83128.0, &
+ 79655.0, 72753.0, 73771.0, 73762.0, 71760.0, 69758.0, 67756.0 /), &
+    e_nox = (/ 25527.0, 25180.0, 25261.0, 25356.0, 25350.0, 24955.0, 24787.0, &
+ 24705.0, 24348.0, 22845.0, 22598.0, 21549.0, 23959.0, 22651.0, 21331.0,      &
+ 20355.0, 19227.0, 18099.0, 16909.0, 15772.0, 14846.0, 14519.0, 13657.0,      &
+ 13072.0, 12412.0 /), &
+    e_pm10 = (/ 27753.0, 27345.0, 27098.0, 27364.0, 28608.0, 25820.0, 22857.0,&
+ 22909.0, 22893.0, 23383.0, 23747.0, 23708.0, 21576.0, 21664.0, 21749.0,      &
+ 21302.0, 21401.0, 21501.0, 21580.0, 21199.0, 20823.0, 20723.0, 20687.0,      &
+ 20651.0, 20616.0 /), &
+    e_pm25 = (/ 7560.0, 7320.0, 7198.0, 7149.0, 7542.0, 6929.0, 6724.0,  &
+ 6256.0, 6261.0, 7211.0, 7288.0, 6996.0, 5805.0, 5888.0, 5970.0, 5592.0, &
+ 5736.0, 5881.0, 6014.0, 5988.0, 5964.0, 6100.0, 6077.0, 6055.0, 6033.0 /), &
+    e_so2 = (/ 23077.0, 22375.0, 22082.0, 21773.0, 21346.0, 18619.0, 18385.0, &
+ 18840.0, 18944.0, 17545.0, 16347.0, 15932.0, 15032.0, 14808.0, 14571.0,      &
+ 14546.0, 13123.0, 11699.0, 10324.0, 9089.0, 7732.0, 6479.0, 5193.0, 5098.0,  &
+ 4991.0 /), &
+    e_voc = (/ 24108.0, 23577.0, 23066.0, 22730.0, 22570.0, 22042.0, 20871.0, &
+ 19530.0, 18781.0, 18270.0, 17512.0, 17111.0, 20289.0, 19911.0, 19514.0,      &
+ 17753.0, 17902.0, 18050.0, 17759.0, 17593.0, 17835.0, 18154.0, 17813.0,      &
+ 17471.0, 17130.0 /), &
+    e_nh3 = (/ 4320.0, 4384.0, 4443.0, 4518.0, 4589.0, 4659.0, 4727.0,        &
+ 4817.0, 4940.0, 4857.0, 4907.0, 3689.0, 3994.0, 4005.0, 4016.0, 3932.0,      &
+ 4077.0, 4222.0, 4359.0, 4315.0, 4271.0, 4232.0, 4227.0, 4221.0, 4216.0 /)
+
+
+CONTAINS
+
+! --------------------------------------------- !
+! Public functions ---------------------------- !
+! --------------------------------------------- !
+
+FUNCTION CO_SCALE( year, base_year_in )
+
+    INTEGER, INTENT(IN)           :: year
+    INTEGER, INTENT(IN), OPTIONAL :: base_year_in
+    INTEGER                       :: base_year, yind, byind
+! Output value
+    REAL*8                        :: co_scale
+
+    IF(PRESENT(base_year_in)) THEN
+        base_year = base_year_in
+    ELSE
+        base_year = def_base_yr
+    ENDIF
+
+    yind = YEAR_INDEX(year)
+    byind = YEAR_INDEX(base_year)
+
+    co_scale = e_co(yind) / e_co(byind)
+
+END FUNCTION
+
+
+FUNCTION NOX_SCALE( year, base_year_in )
+
+    INTEGER, INTENT(IN)           :: year
+    INTEGER, INTENT(IN), OPTIONAL :: base_year_in
+    INTEGER                       :: base_year, yind, byind
+! Output value
+    REAL*8                        :: nox_scale
+
+    IF(PRESENT(base_year_in)) THEN
+        base_year = base_year_in
+    ELSE
+        base_year = def_base_yr
+    ENDIF
+
+    yind = YEAR_INDEX(year)
+    byind = YEAR_INDEX(base_year)
+
+    nox_scale = e_nox(yind) / e_nox(byind)
+
+END FUNCTION
+
+
+FUNCTION PM10_SCALE( year, base_year_in )
+
+    INTEGER, INTENT(IN)           :: year
+    INTEGER, INTENT(IN), OPTIONAL :: base_year_in
+    INTEGER                       :: base_year, yind, byind
+! Output value
+    REAL*8                        :: pm10_scale
+
+    IF(PRESENT(base_year_in)) THEN
+        base_year = base_year_in
+    ELSE
+        base_year = def_base_yr
+    ENDIF
+
+    yind = YEAR_INDEX(year)
+    byind = YEAR_INDEX(base_year)
+
+    pm10_scale = e_pm10(yind) / e_pm10(byind)
+
+END FUNCTION
+
+
+FUNCTION PM25_SCALE( year, base_year_in )
+
+    INTEGER, INTENT(IN)           :: year
+    INTEGER, INTENT(IN), OPTIONAL :: base_year_in
+    INTEGER                       :: base_year, yind, byind
+! Output value
+    REAL*8                        :: pm25_scale
+
+    IF(PRESENT(base_year_in)) THEN
+        base_year = base_year_in
+    ELSE
+        base_year = def_base_yr
+    ENDIF
+
+    yind = YEAR_INDEX(year)
+    byind = YEAR_INDEX(base_year)
+
+    pm25_scale = e_pm25(yind) / e_pm25(byind)
+
+END FUNCTION
+
+
+FUNCTION SO2_SCALE( year, base_year_in )
+
+    INTEGER, INTENT(IN)           :: year
+    INTEGER, INTENT(IN), OPTIONAL :: base_year_in
+    INTEGER                       :: base_year, yind, byind
+! Output value
+    REAL*8                        :: so2_scale
+
+    IF(PRESENT(base_year_in)) THEN
+        base_year = base_year_in
+    ELSE
+        base_year = def_base_yr
+    ENDIF
+
+    yind = YEAR_INDEX(year)
+    byind = YEAR_INDEX(base_year)
+
+    so2_scale = e_so2(yind) / e_so2(byind)
+
+END FUNCTION
+
+FUNCTION VOC_SCALE( year, base_year_in )
+
+    INTEGER, INTENT(IN)           :: year
+    INTEGER, INTENT(IN), OPTIONAL :: base_year_in
+    INTEGER                       :: base_year, yind, byind
+! Output value
+    REAL*8                        :: voc_scale
+
+    IF(PRESENT(base_year_in)) THEN
+        base_year = base_year_in
+    ELSE
+        base_year = def_base_yr
+    ENDIF
+
+    yind = YEAR_INDEX(year)
+    byind = YEAR_INDEX(base_year)
+
+    voc_scale = e_voc(yind) / e_voc(byind)
+
+END FUNCTION
+
+
+FUNCTION NH3_SCALE( year, base_year_in )
+
+    INTEGER, INTENT(IN)           :: year
+    INTEGER, INTENT(IN), OPTIONAL :: base_year_in
+    INTEGER                       :: base_year, yind, byind
+! Output value
+    REAL*8                        :: nh3_scale
+
+    IF(PRESENT(base_year_in)) THEN
+        base_year = base_year_in
+    ELSE
+        base_year = def_base_yr
+    ENDIF
+
+    yind = YEAR_INDEX(year)
+    byind = YEAR_INDEX(base_year)
+
+    nh3_scale = e_nh3(yind) / e_nh3(byind)
+
+END FUNCTION
+! -------------------------------------------- !
+! Private functions -------------------------- !
+! -------------------------------------------- !
+
+FUNCTION YEAR_INDEX( year )
+    INTEGER, INTENT(IN)     :: year
+    INTEGER                 :: year_index, i
+
+    DO i=1,size(years)
+        IF(year == years(i)) THEN
+            year_index = i
+            exit
+        ENDIF
+    ENDDO
+
+END FUNCTION
+
+END MODULE


### PR DESCRIPTION
NEW FILES:
    chem/module_emiss_scale.F - this has the year-by-year total emissions for
the various anthropogenic species included. When given a base year and current
year, its functions return the ratio of the current year to base year total
emissions to scale the emissions array in convert_emiss.

MODIFIED FILES:
    chem/convert_emiss.F - uses module_emiss_scale to scale the various NEI
anthropogenic emissions.

    chem/Makefile_org - modified to include module_emiss_scale as a dependency
for convert_emiss.